### PR TITLE
fixed README style bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ $form->largefile('ColumnName', 'LabelName');
 ![](preview.png)
 
 上传中
+
 ![](onload.png)
 ----
 新版2.0分支更新的内容


### PR DESCRIPTION
Currently, README file would be parsed by Github as:
![image](https://user-images.githubusercontent.com/19504567/130782710-0cbb2285-115f-44c8-8283-b3306119228f.png)

This small patch fixed the styling bug by adding a blank line after the sentence.